### PR TITLE
Dont requeue stalled jobs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
   "rules": {
     "array-bracket-spacing": [2, "never"],
     "brace-style": [2, "1tbs"],

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ logs
 notes.txt
 node_modules
 dump.rdb
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,15 +4,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-githooks');
 
   grunt.initConfig({
-    eslint: {
-      options: {
-        config: '.eslintrc'
-      },
-      target: [
-        'lib/**/*.js',
-        'test/**/*.js'
-      ]
-    },
+		eslint: {
+			options: {
+				config: '.eslintrc'
+			},
+			target: [
+				'lib/**/*.js',
+				'test/**/*.js'
+			]
+		},
     mochaTest: {
       test: {
         options: {
@@ -30,4 +30,5 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['eslint']);
   grunt.registerTask('test', ['eslint', 'mochaTest']);
+  grunt.registerTask('test-only', ['mochaTest']);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 class BeeQueueError extends Error {}
 class JobNotFoundBeeQueueError extends BeeQueueError {}
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,10 @@
+'use strict';
+
+
+class BeeQueueError extends Error {}
+class JobNotFoundBeeQueueError extends BeeQueueError {}
+
+module.exports  = {
+	BeeQueueError: BeeQueueError,
+	JobNotFoundBeeQueueError: JobNotFoundBeeQueueError
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,16 @@ var defaultCb = function (err) {
   }
 };
 
+var restartOnError = function(client, tick) {
+	var restart = function() {
+		client.on('ready', tick);
+	};
+	client.on('error', restart);
+	client.on('end', restart);
+};
+
 module.exports = {
   barrier: barrier,
-  defaultCb: defaultCb
+  defaultCb: defaultCb,
+	restartOnError: restartOnError
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -95,6 +95,10 @@ Job.prototype.retries = function (n) {
   return this;
 };
 
+Job.prototype.isFirstAttempt = function () {
+  return this.options.retries == this.options.maxRetries;
+};
+
 /**
  * Whether to enable backoff - currently its just exponential but in the future we might support different types of backoffs
  * exponential, fixed, or using an user defined function

--- a/lib/job.js
+++ b/lib/job.js
@@ -114,7 +114,7 @@ Job.prototype.backoff = function (backoff) {
 
 /**
  * Number of miliseconds to wait until retrying this job again.
- * Exponential backoff based on delay (or 1sec) - max 5 minutes + (0, 10) seconds random delay
+ * Exponential backoff based on delay (or 1sec) - max 5 minutes + (0, 60) seconds random delay
  *
  * @returns {number}
  */
@@ -125,7 +125,7 @@ Job.prototype.backoffDelay = function () {
   const tryNumber = this.options.maxRetries - this.options.retries;
   const delay = this.options.delay || 1000;
   const number = Math.round(delay * Math.pow(2, tryNumber));
-  return Math.min(number, 5 * 60 * 1000) + Math.random() * 10 * 1000;
+  return Math.min(number, 5 * 60 * 1000) + Math.random() * 60 * 1000;
 };
 
 Job.prototype.timeout = function (ms) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -128,6 +128,14 @@ Job.prototype.remove = function (cb) {
   );
 };
 
+Job.prototype.removeMulti = function (multi) {
+  multi.evalsha(lua.shas.removeJob, 7,
+      this.queue.toKey('succeeded'), this.queue.toKey('failed'), this.queue.toKey('waiting'),
+      this.queue.toKey('active'), this.queue.toKey('stalling'), this.queue.toKey('schedule'), this.queue.toKey('jobs'),
+      this.id
+  );
+};
+
 Job.prototype.retry = function (cb) {
   cb = cb || helpers.defaultCb;
   this.queue.client.multi()

--- a/lib/job.js
+++ b/lib/job.js
@@ -120,9 +120,9 @@ Job.prototype.reportProgress = function (progress, cb) {
 
 Job.prototype.remove = function (cb) {
   cb = cb || helpers.defaultCb;
-  this.queue.client.evalsha(lua.shas.removeJob, 6,
+  this.queue.client.evalsha(lua.shas.removeJob, 7,
     this.queue.toKey('succeeded'), this.queue.toKey('failed'), this.queue.toKey('waiting'),
-    this.queue.toKey('active'), this.queue.toKey('stalling'), this.queue.toKey('jobs'),
+    this.queue.toKey('active'), this.queue.toKey('stalling'), this.queue.toKey('schedule'), this.queue.toKey('jobs'),
     this.id,
     cb
   );

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var events = require('events');
 var util = require('util');
 
@@ -19,6 +21,9 @@ Job.fromId = function (queue, jobId, cb) {
   queue.client.hget(queue.toKey('jobs'), jobId, function (err, data) {
     /* istanbul ignore if */
     if (err) return cb(err);
+    if(!data) {
+      throw new Error(`Job ${jobId} not found`);
+    }
     return cb(null, Job.fromData(queue, jobId, data));
   });
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -114,7 +114,7 @@ Job.prototype.backoff = function (backoff) {
 
 /**
  * Number of miliseconds to wait until retrying this job again.
- * Exponential backoff based on delay (or 1sec) - max 5 minutes
+ * Exponential backoff based on delay (or 1sec) - max 5 minutes + (0, 10) seconds random delay
  *
  * @returns {number}
  */
@@ -124,8 +124,8 @@ Job.prototype.backoffDelay = function () {
   }
   const tryNumber = this.options.maxRetries - this.options.retries;
   const delay = this.options.delay || 1000;
-  const number = Math.round(delay * Math.pow(2, tryNumber) + Math.random() * 1000);
-  return Math.min(number, 5*60*1000);
+  const number = Math.round(delay * Math.pow(2, tryNumber));
+  return Math.min(number, 5 * 60 * 1000) + Math.random() * 10 * 1000;
 };
 
 Job.prototype.timeout = function (ms) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -91,8 +91,28 @@ Job.prototype.retries = function (n) {
   if (n < 0) {
     throw new this.queue.errors.BeeQueueError('Retries cannot be negative');
   }
-  this.options.retries = n;
+  this.options.retries = this.options.maxRetries = n;
   return this;
+};
+
+Job.prototype.backoff = function (backoff) {
+  backoff = !!backoff;
+  this.options.backoff = backoff;
+  return this;
+};
+
+/**
+ * Number of miliseconds to wait until retrying this job again
+ * @returns {number}
+ */
+Job.prototype.backoffDelay = function () {
+  if(!this.options.backoff) {
+    return 0;
+  }
+  const tryNumber = this.options.maxRetries - this.options.retries;
+  const delay = this.options.delay || 1000;
+  const number = Math.round(delay * 0.5 * ( Math.pow(2, tryNumber) - 1));
+  return number;
 };
 
 Job.prototype.timeout = function (ms) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -42,17 +42,42 @@ Job.prototype.toData = function () {
 Job.prototype.save = function (cb) {
   cb = cb || helpers.defaultCb;
   var self = this;
-  this.queue.client.evalsha(lua.shas.addJob, 3,
-    this.queue.toKey('id'), this.queue.toKey('jobs'), this.queue.toKey('waiting'),
-    this.toData(),
-    function (err, jobId) {
-      /* istanbul ignore if */
-      if (err) return cb(err);
-      self.id = jobId;
-      self.queue.jobs[jobId] = self;
-      return cb(null, self);
-    }
-  );
+
+  if (self.options.delay) {
+    var delayVal = new Date().getTime() + self.options.delay;
+    this.queue.client.evalsha(lua.shas.addDelayJob, 3,
+        this.queue.toKey('id'), this.queue.toKey('jobs'), this.queue.toKey('schedule'),
+        this.toData(),
+        delayVal,
+        function (err, jobId) {
+          /* istanbul ignore if */
+          if (err) return cb(err);
+          self.id = jobId;
+          self.queue.jobs[jobId] = self;
+          return cb(null, self);
+        }
+    );
+  } else {
+    this.queue.client.evalsha(lua.shas.addJob, 3,
+        this.queue.toKey('id'), this.queue.toKey('jobs'), this.queue.toKey('waiting'),
+        this.toData(),
+        function (err, jobId) {
+          /* istanbul ignore if */
+          if (err) return cb(err);
+          self.id = jobId;
+          self.queue.jobs[jobId] = self;
+          return cb(null, self);
+        }
+    );
+  }
+  return this;
+};
+
+Job.prototype.delay = function (n) {
+  if (n <= 0) {
+    throw Error('delay cannot be negative');
+  }
+  this.options.delay = n;
   return this;
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -95,6 +95,13 @@ Job.prototype.retries = function (n) {
   return this;
 };
 
+/**
+ * Whether to enable backoff - currently its just exponential but in the future we might support different types of backoffs
+ * exponential, fixed, or using an user defined function
+ *
+ * @param backoff
+ * @returns {Job}
+ */
 Job.prototype.backoff = function (backoff) {
   backoff = !!backoff;
   this.options.backoff = backoff;
@@ -102,7 +109,9 @@ Job.prototype.backoff = function (backoff) {
 };
 
 /**
- * Number of miliseconds to wait until retrying this job again
+ * Number of miliseconds to wait until retrying this job again.
+ * Exponential backoff based on delay (or 1sec)
+ *
  * @returns {number}
  */
 Job.prototype.backoffDelay = function () {

--- a/lib/job.js
+++ b/lib/job.js
@@ -22,7 +22,7 @@ Job.fromId = function (queue, jobId, cb) {
     /* istanbul ignore if */
     if (err) return cb(err);
     if(!data) {
-      throw new Error(`Job ${jobId} not found`);
+      throw new Error(`Job ${jobId} not found in queue ${queue.name}`);
     }
     return cb(null, Job.fromData(queue, jobId, data));
   });

--- a/lib/job.js
+++ b/lib/job.js
@@ -124,7 +124,7 @@ Job.prototype.backoffDelay = function () {
   }
   const tryNumber = this.options.maxRetries - this.options.retries;
   const delay = this.options.delay || 1000;
-  const number = Math.round(delay * 0.5 * ( Math.pow(2, tryNumber) - 1));
+  const number = Math.round(delay * Math.pow(2, tryNumber) + Math.random() * 1000);
   return Math.min(number, 5*60*1000);
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -6,6 +6,7 @@ var util = require('util');
 var helpers = require('./helpers');
 var lua = require('./lua');
 
+
 function Job(queue, jobId, data, options) {
   this.queue = queue;
   this.id = jobId;
@@ -22,7 +23,7 @@ Job.fromId = function (queue, jobId, cb) {
     /* istanbul ignore if */
     if (err) return cb(err);
     if(!data) {
-      throw new Error(`Job ${jobId} not found in queue ${queue.name}`);
+      throw new queue.errors.JobNotFoundBeeQueueError(`Job ${jobId} not found in queue ${queue.name}`);
     }
     return cb(null, Job.fromData(queue, jobId, data));
   });
@@ -80,7 +81,7 @@ Job.prototype.save = function (cb) {
 
 Job.prototype.delay = function (n) {
   if (n <= 0) {
-    throw Error('delay cannot be negative');
+    throw new this.queue.errors.BeeQueueError('delay cannot be negative');
   }
   this.options.delay = n;
   return this;
@@ -88,7 +89,7 @@ Job.prototype.delay = function (n) {
 
 Job.prototype.retries = function (n) {
   if (n < 0) {
-    throw Error('Retries cannot be negative');
+    throw new this.queue.errors.BeeQueueError('Retries cannot be negative');
   }
   this.options.retries = n;
   return this;
@@ -96,7 +97,7 @@ Job.prototype.retries = function (n) {
 
 Job.prototype.timeout = function (ms) {
   if (ms < 0) {
-    throw Error('Timeout cannot be negative');
+    throw new this.queue.errors.BeeQueueError('Timeout cannot be negative');
   }
   this.options.timeout = ms;
   return this;
@@ -108,7 +109,7 @@ Job.prototype.reportProgress = function (progress, cb) {
   cb = cb || helpers.defaultCb;
   progress = Number(progress);
   if (progress < 0 || progress > 100) {
-    return process.nextTick(cb.bind(null, Error('Progress must be between 0 and 100')));
+    return process.nextTick(cb.bind(null, new this.queue.errors.BeeQueueError('Progress must be between 0 and 100')));
   }
   this.progress = progress;
   this.queue.client.publish(this.queue.toKey('events'), JSON.stringify({

--- a/lib/job.js
+++ b/lib/job.js
@@ -114,7 +114,7 @@ Job.prototype.backoff = function (backoff) {
 
 /**
  * Number of miliseconds to wait until retrying this job again.
- * Exponential backoff based on delay (or 1sec)
+ * Exponential backoff based on delay (or 1sec) - max 5 minutes
  *
  * @returns {number}
  */
@@ -125,7 +125,7 @@ Job.prototype.backoffDelay = function () {
   const tryNumber = this.options.maxRetries - this.options.retries;
   const delay = this.options.delay || 1000;
   const number = Math.round(delay * 0.5 * ( Math.pow(2, tryNumber) - 1));
-  return number;
+  return Math.min(number, 5*60*1000);
 };
 
 Job.prototype.timeout = function (ms) {

--- a/lib/lua/addDelayJob.lua
+++ b/lib/lua/addDelayJob.lua
@@ -1,0 +1,12 @@
+--[[
+key 1 -> bq:name:id (job ID counter)
+key 2 -> bq:name:jobs
+key 3 -> bq:name:schedule
+arg 1 -> job data
+]]
+
+local jobId = redis.call("incr", KEYS[1])
+redis.call("hset", KEYS[2], jobId, ARGV[1])
+redis.call("zadd", KEYS[3], ARGV[2], jobId)
+
+return jobId

--- a/lib/lua/addDelayJob.lua
+++ b/lib/lua/addDelayJob.lua
@@ -3,6 +3,7 @@ key 1 -> bq:name:id (job ID counter)
 key 2 -> bq:name:jobs
 key 3 -> bq:name:schedule
 arg 1 -> job data
+arg 2 -> schedule timestamp
 ]]
 
 local jobId = redis.call("incr", KEYS[1])

--- a/lib/lua/checkDelay.lua
+++ b/lib/lua/checkDelay.lua
@@ -1,0 +1,18 @@
+--[[
+key 1 -> bq:name:schedulelock
+key 2 -> bq:name:schedule
+key 3 -> bq:name:waiting
+arg 1 -> process id (e.g: ip+pid+random number)
+arg 2 -> maxscore (current time, e.g: 1453195007000)
+]]
+local count = 0
+redis.call("set", KEYS[1], ARGV[1], "EX", 2, "NX")
+if redis.call("get", KEYS[1]) == ARGV[1] then
+	local delays = redis.call("zrangebyscore", KEYS[2], 0, ARGV[2], "limit", 0, 1000)
+	for i= 1, #delays do
+		redis.call("rpush", KEYS[3], delays[i])
+		redis.call("zrem", KEYS[2], delays[i])
+	end
+	count = #delays
+end
+return count

--- a/lib/lua/checkStalledJobs.lua
+++ b/lib/lua/checkStalledJobs.lua
@@ -13,6 +13,11 @@ if a jobId is not removed from the stalling set within a stallInterval window,
 we assume the job has stalled and should be reset (moved from active back to waiting)
 --]]
 
+-- For now don't move stalling jobs back to waiting.
+-- This means we no longer have at least once delivery
+return 0
+
+
 local now = tonumber(ARGV[1])
 local stallTime = tonumber(redis.call("get", KEYS[1]) or 0)
 

--- a/lib/lua/removeJob.lua
+++ b/lib/lua/removeJob.lua
@@ -4,7 +4,8 @@ key 2 -> bq:test:failed
 key 3 -> bq:test:waiting
 key 4 -> bq:test:active
 key 5 -> bq:test:stalling
-key 6 -> bq:test:jobs
+key 6 -> bq:test:schedule
+key 7 -> bq:test:jobs
 arg 1 -> jobId
 ]]
 
@@ -18,4 +19,5 @@ end
 redis.call("srem", KEYS[1], jobId)
 redis.call("srem", KEYS[2], jobId)
 redis.call("srem", KEYS[5], jobId)
-redis.call("hdel", KEYS[6], jobId)
+redis.call("zrem", KEYS[6], jobId)
+redis.call("hdel", KEYS[7], jobId)

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -122,7 +122,7 @@ Queue.prototype.close = function (cb) {
   });
 
   clients.forEach(function (client) {
-    client.end();
+    client.end(false);
     client.stream.on('close', handleEnd);
   });
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -295,7 +295,7 @@ Queue.prototype.schedule = function (interval, handler) {
 				self.toKey('schedulelock'),
 				self.toKey('schedule'),
 				self.toKey('waiting'),
-				os.hostname() + ':' + process.pid + this._random,
+				os.hostname() + ':' + process.pid + self._random,
 				new Date().getTime(),
 				function (err, count) {
 					if (err) return console.error(err);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,15 +1,18 @@
 'use strict';
 
-var redis = require('redis');
-var events = require('events');
-var util = require('util');
-var os = require('os');
+const redis = require('redis');
+const events = require('events');
+const util = require('util');
+const os = require('os');
 
-var Job = require('./job');
-var defaults = require('./defaults');
-var lua = require('./lua');
-var helpers = require('./helpers');
-var barrier = helpers.barrier;
+const Job = require('./job');
+const defaults = require('./defaults');
+const lua = require('./lua');
+const helpers = require('./helpers');
+const barrier = helpers.barrier;
+const errors = require('./errors');
+const BeeQueueError = errors.BeeQueueError;
+
 
 function Queue(name, settings) {
   if (!(this instanceof Queue)) {
@@ -80,7 +83,7 @@ util.inherits(Queue, events.EventEmitter);
 Queue.prototype.onMessage = function (channel, message) {
   message = JSON.parse(message);
   if (message.event === 'failed' || message.event === 'retrying') {
-    message.data = new Queue.errors.BeeQueueError(message.data);
+    message.data = new BeeQueueError(message.data);
   }
 
   this.emit('job ' + message.event, message.id, message.data);
@@ -106,7 +109,7 @@ Queue.prototype.close = function (cb) {
 
   /* istanbul ignore next */
   var closeTimeout = setTimeout(function () {
-    return cb(new Queue.errors.BeeQueueError('Timed out closing redis connections'));
+    return cb(new BeeQueueError('Timed out closing redis connections'));
   }, 5000);
 
   var clients = [this.client];
@@ -209,7 +212,7 @@ Queue.prototype.runJob = function (job, cb) {
 
   if (job.options.timeout) {
     var msg = 'Job ' + job.id + ' timed out (' + job.options.timeout + ' ms)';
-    setTimeout(handleOutcome.bind(null, new Queue.errors.BeeQueueError(msg)), job.options.timeout);
+    setTimeout(handleOutcome.bind(null, new BeeQueueError(msg)), job.options.timeout);
   }
 
   if (this.settings.catchExceptions) {
@@ -292,11 +295,11 @@ Queue.prototype.schedule = function (interval) {
 
 Queue.prototype.process = function (concurrency, handler) {
   if (!this.settings.isWorker) {
-    throw new Queue.errors.BeeQueueError('Cannot call Queue.prototype.process on a non-worker');
+    throw new BeeQueueError('Cannot call Queue.prototype.process on a non-worker');
   }
 
   if (this.handler) {
-    throw new Queue.errors.BeeQueueError('Cannot call Queue.prototype.process twice');
+    throw new BeeQueueError('Cannot call Queue.prototype.process twice');
   }
 
   if (typeof concurrency === 'function') {
@@ -381,6 +384,6 @@ Queue.prototype.toKey = function (str) {
   return this.settings.keyPrefix + str;
 };
 
-Queue.prototype.errors = require('./errors');
+Queue.prototype.errors = errors;
 
 module.exports = Queue;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -130,7 +130,7 @@ Queue.prototype.close = function (cb) {
   });
 
   clients.forEach(function (client) {
-    client.quit();
+    client.end(false);
     client.stream.on('close', handleEnd);
   });
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -19,7 +19,7 @@ function Queue(name, settings) {
     return new Queue(name, settings);
   }
 
-  this._random = Math.floor(Math.random() * 10000);
+  this._random = Math.floor(Math.random() * 1000000);
   this.name = name;
   this.paused = false;
   this.jobs = {};
@@ -295,7 +295,7 @@ Queue.prototype.schedule = function (interval, handler) {
 				self.toKey('schedulelock'),
 				self.toKey('schedule'),
 				self.toKey('waiting'),
-				os.hostname() + ':' + process.pid + self._random,
+				os.hostname() + ':' + process.pid + ':' + self._random,
 				new Date().getTime(),
 				function (err, count) {
 					if (err) return console.error(err);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -248,8 +248,15 @@ Queue.prototype.finishJob = function (err, data, job, cb) {
       job.options.retries -= 1;
       job.status = 'retrying';
       jobEvent.event = 'retrying';
-      multi.hset(this.toKey('jobs'), job.id, job.toData())
-           .lpush(this.toKey('waiting'), job.id);
+      const backoffDelay = job.backoffDelay();
+      if(backoffDelay) {
+        const delayVal = new Date().getTime() + backoffDelay;
+        multi.hset(this.toKey('jobs'), job.id, job.toData())
+            .zadd(this.toKey('schedule'), delayVal, job.id);
+      } else {
+        multi.hset(this.toKey('jobs'), job.id, job.toData())
+            .lpush(this.toKey('waiting'), job.id);
+      }
     } else {
       job.status = 'failed';
       multi.hset(this.toKey('jobs'), job.id, job.toData())

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -285,23 +285,30 @@ Queue.prototype.finishJob = function (err, data, job, cb) {
   });
 };
 
-Queue.prototype.schedule = function (interval) {
+Queue.prototype.schedule = function (interval, handler) {
   var self = this;
-  var startTime = new Date().getTime();
   interval = interval || 500;
-  self.client.evalsha(lua.shas.checkDelay, 3,
-      self.toKey('schedulelock'),
-      self.toKey('schedule'),
-      self.toKey('waiting'),
-      os.hostname() + ':' + process.pid + this._random,
-      new Date().getTime(),
-      function (err, count) {
-        if (err) return console.error(err);
-        var delay = startTime - new Date().getTime() + interval;
-        if (delay < 1)setImmediate(self.schedule.bind(self), interval);
-        else setTimeout(self.schedule.bind(self), delay, interval);
-      }
-  );
+
+	var tick = function() {
+		var startTime = new Date().getTime();
+		self.client.evalsha(lua.shas.checkDelay, 3,
+				self.toKey('schedulelock'),
+				self.toKey('schedule'),
+				self.toKey('waiting'),
+				os.hostname() + ':' + process.pid + this._random,
+				new Date().getTime(),
+				function (err, count) {
+					if (err) return console.error(err);
+					if (handler) handler(err);
+					var delay = startTime - new Date().getTime() + interval;
+					if (delay < 1) setImmediate(tick);
+					else setTimeout(tick, delay);
+				}
+		);
+	};
+
+	helpers.restartOnError(this.client, tick);
+	setImmediate(tick);
 };
 
 Queue.prototype.process = function (concurrency, handler) {
@@ -362,12 +369,7 @@ Queue.prototype.process = function (concurrency, handler) {
     });
   };
 
-  var restartProcessing = function () {
-    // maybe need to increment queued here?
-    self.bclient.once('ready', jobTick);
-  };
-  this.bclient.on('error', restartProcessing);
-  this.bclient.on('end', restartProcessing);
+	helpers.restartOnError(this.bclient, jobTick);
 
   this.checkStalledJobs(setImmediate.bind(null, jobTick));
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -80,7 +80,7 @@ util.inherits(Queue, events.EventEmitter);
 Queue.prototype.onMessage = function (channel, message) {
   message = JSON.parse(message);
   if (message.event === 'failed' || message.event === 'retrying') {
-    message.data = Error(message.data);
+    message.data = new Queue.errors.BeeQueueError(message.data);
   }
 
   this.emit('job ' + message.event, message.id, message.data);
@@ -106,7 +106,7 @@ Queue.prototype.close = function (cb) {
 
   /* istanbul ignore next */
   var closeTimeout = setTimeout(function () {
-    return cb(Error('Timed out closing redis connections'));
+    return cb(new Queue.errors.BeeQueueError('Timed out closing redis connections'));
   }, 5000);
 
   var clients = [this.client];
@@ -209,7 +209,7 @@ Queue.prototype.runJob = function (job, cb) {
 
   if (job.options.timeout) {
     var msg = 'Job ' + job.id + ' timed out (' + job.options.timeout + ' ms)';
-    setTimeout(handleOutcome.bind(null, Error(msg)), job.options.timeout);
+    setTimeout(handleOutcome.bind(null, new Queue.errors.BeeQueueError(msg)), job.options.timeout);
   }
 
   if (this.settings.catchExceptions) {
@@ -292,11 +292,11 @@ Queue.prototype.schedule = function (interval) {
 
 Queue.prototype.process = function (concurrency, handler) {
   if (!this.settings.isWorker) {
-    throw Error('Cannot call Queue.prototype.process on a non-worker');
+    throw new Queue.errors.BeeQueueError('Cannot call Queue.prototype.process on a non-worker');
   }
 
   if (this.handler) {
-    throw Error('Cannot call Queue.prototype.process twice');
+    throw new Queue.errors.BeeQueueError('Cannot call Queue.prototype.process twice');
   }
 
   if (typeof concurrency === 'function') {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -250,7 +250,7 @@ Queue.prototype.finishJob = function (err, data, job, cb) {
     job.status = 'succeeded';
     multi.hset(this.toKey('jobs'), job.id, job.toData());
     if (this.settings.removeOnSuccess) {
-      multi.hdel(this.toKey('jobs'), job.id);
+      job.removeMulti(multi);
     } else {
       multi.sadd(this.toKey('succeeded'), job.id);
     }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -124,7 +124,7 @@ Queue.prototype.close = function (cb) {
   });
 
   clients.forEach(function (client) {
-    client.end(false);
+    client.quit();
     client.stream.on('close', handleEnd);
   });
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -19,6 +19,7 @@ function Queue(name, settings) {
     return new Queue(name, settings);
   }
 
+  this._random = Math.floor(Math.random() * 10000);
   this.name = name;
   this.paused = false;
   this.jobs = {};
@@ -285,7 +286,7 @@ Queue.prototype.schedule = function (interval) {
       self.toKey('schedulelock'),
       self.toKey('schedule'),
       self.toKey('waiting'),
-      os.hostname() + ':' + process.pid + Math.floor(Math.random() * 10000),
+      os.hostname() + ':' + process.pid + this._random,
       new Date().getTime(),
       function (err, count) {
         if (err) return console.error(err);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -58,10 +58,6 @@ function Queue(name, settings) {
 
   var makeClient = function (clientName) {
     this[clientName] = redis.createClient.apply(redis, this.settings.redis.params);
-    this[clientName].on('error', (err) => {
-      console.error(`BeeQueue: Caught error ${err}`);
-      this.emit('error', err);
-    });
     this[clientName].select(this.settings.redis.db, reportReady);
   }.bind(this);
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -57,7 +57,10 @@ function Queue(name, settings) {
 
   var makeClient = function (clientName) {
     this[clientName] = redis.createClient.apply(redis, this.settings.redis.params);
-    this[clientName].on('error', this.emit.bind(this, 'error'));
+    this[clientName].on('error', (err) => {
+      console.error(`BeeQueue: Caught error ${err}`);
+      this.emit('error', err);
+    });
     this[clientName].select(this.settings.redis.db, reportReady);
   }.bind(this);
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,6 +1,7 @@
 var redis = require('redis');
 var events = require('events');
 var util = require('util');
+var os = require('os');
 
 var Job = require('./job');
 var defaults = require('./defaults');
@@ -128,7 +129,7 @@ Queue.prototype.close = function (cb) {
 
 Queue.prototype.destroy = function (cb) {
   cb = cb || helpers.defaultCb;
-  var keys = ['id', 'jobs', 'stallTime', 'stalling', 'waiting', 'active', 'succeeded', 'failed']
+  var keys = ['id', 'jobs', 'stallTime', 'stalling', 'waiting', 'active', 'succeeded', 'failed', 'schedule', 'schedulelock']
     .map(this.toKey.bind(this));
   this.client.del.apply(this.client, keys.concat(cb));
 };
@@ -266,6 +267,25 @@ Queue.prototype.finishJob = function (err, data, job, cb) {
     }
     return cb(null, status, err ? err : data);
   });
+};
+
+Queue.prototype.schedule = function (interval) {
+  var self = this;
+  var startTime = new Date().getTime();
+  interval = interval || 500;
+  self.client.evalsha(lua.shas.checkDelay, 3,
+      self.toKey('schedulelock'),
+      self.toKey('schedule'),
+      self.toKey('waiting'),
+      os.hostname() + ':' + process.pid + Math.floor(Math.random() * 10000),
+      new Date().getTime(),
+      function (err, count) {
+        if (err) return console.error(err);
+        var delay = startTime - new Date().getTime() + interval;
+        if (delay < 1)setImmediate(self.schedule.bind(self), interval);
+        else setTimeout(self.schedule.bind(self), delay, interval);
+      }
+  );
 };
 
 Queue.prototype.process = function (concurrency, handler) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var redis = require('redis');
 var events = require('events');
 var util = require('util');
@@ -378,5 +380,7 @@ Queue.prototype.checkStalledJobs = function (interval, cb) {
 Queue.prototype.toKey = function (str) {
   return this.settings.keyPrefix + str;
 };
+
+Queue.prototype.errors = require('./errors');
 
 module.exports = Queue;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple, fast, robust job/task queue, backed by Redis.",
   "main": "index.js",
   "dependencies": {
-    "redis": "1.0.0"
+    "grunt-cli": "^1.2.0",
+    "redis": "2.6.0-2"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "grunt-cli": "^1.2.0",
-    "redis": "2.6.0-2"
+    "redis": "2.6.1"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "grunt-cli": "^1.2.0",
-    "redis": "2.6.1"
+    "redis": "2.6.2"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
Too many problems with workers crashing and bee-queue continually re-enqueuing the job, which just makes them crash again.
For now lets keep the crashed jobs in the "stalling" queue instead of automatically moving them back to the waiting queue.