### PR TITLE
Switch from JSON.parse/stringify to msgpack-lite

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,11 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+        "jsx": true
+    }
+  },
   "rules": {
     "array-bracket-spacing": [2, "never"],
     "brace-style": [2, "1tbs"],
@@ -30,7 +37,7 @@
     "quotes": [2, "single"],
     "semi": [2, "always"],
     "semi-spacing": [2, {"before": false, "after": true}],
-    "space-after-keywords": [2, "always"],
+    "keyword-spacing": [2, {"after": true}],
     "space-before-blocks": 2,
     "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-in-parens": 2,

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
+  - "4"
 services: redis
 after_script:
   - redis-cli script flush

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,5 +1,6 @@
-var events = require('events');
-var util = require('util');
+const events = require('events');
+const util = require('util');
+const msgpack = require('msgpack-lite');
 
 var helpers = require('./helpers');
 var lua = require('./lua');
@@ -25,14 +26,14 @@ Job.fromId = function (queue, jobId, cb) {
 
 Job.fromData = function (queue, jobId, data) {
   // no need for try-catch here since we made the JSON ourselves in job#toData
-  data = JSON.parse(data);
+  data = msgpack.decode(data);
   var job = new Job(queue, jobId, data.data, data.options);
   job.status = data.status;
   return job;
 };
 
 Job.prototype.toData = function () {
-  return JSON.stringify({
+  return msgpack.encode({
     data: this.data,
     options: this.options,
     status: this.status
@@ -81,7 +82,7 @@ Job.prototype.reportProgress = function (progress, cb) {
     return process.nextTick(cb.bind(null, Error('Progress must be between 0 and 100')));
   }
   this.progress = progress;
-  this.queue.client.publish(this.queue.toKey('events'), JSON.stringify({
+  this.queue.client.publish(this.queue.toKey('events'), msgpack.encode({
     id: this.id,
     event: 'progress',
     data: progress

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,6 +1,6 @@
-const events = require('events');
-const util = require('util');
-const msgpack = require('msgpack-lite');
+var events = require('events');
+var util = require('util');
+var msgpack = require('msgpack-lite');
 
 var helpers = require('./helpers');
 var lua = require('./lua');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,6 +1,7 @@
-var redis = require('redis');
-var events = require('events');
-var util = require('util');
+const redis = require('redis');
+const events = require('events');
+const util = require('util');
+const msgpack = require('msgpack-lite');
 
 var Job = require('./job');
 var defaults = require('./defaults');
@@ -25,6 +26,9 @@ function Queue(name, settings) {
       defaults.stallInterval,
     keyPrefix: (settings.prefix || defaults.prefix) + ':' + this.name + ':'
   };
+
+  var redisOpt = {'return_buffers': true};
+  this.settings.redis.options = this.settings.redis.options ? Object.assign(this.settings.redis.options, redisOpt) : redisOpt;
 
   var boolProps = ['isWorker', 'getEvents', 'sendEvents', 'removeOnSuccess', 'catchExceptions'];
   boolProps.forEach(function (prop) {
@@ -75,7 +79,7 @@ function Queue(name, settings) {
 util.inherits(Queue, events.EventEmitter);
 
 Queue.prototype.onMessage = function (channel, message) {
-  message = JSON.parse(message);
+  message = msgpack.decode(message);
   if (message.event === 'failed' || message.event === 'retrying') {
     message.data = Error(message.data);
   }
@@ -121,7 +125,7 @@ Queue.prototype.close = function (cb) {
   });
 
   clients.forEach(function (client) {
-    client.end();
+    client.end(false);
     client.stream.on('close', handleEnd);
   });
 };
@@ -256,7 +260,7 @@ Queue.prototype.finishJob = function (err, data, job, cb) {
   }
 
   if (this.settings.sendEvents) {
-    multi.publish(this.toKey('events'), JSON.stringify(jobEvent));
+    multi.publish(this.toKey('events'), msgpack.encode(jobEvent));
   }
 
   multi.exec(function (errMulti) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,7 +1,7 @@
-const redis = require('redis');
-const events = require('events');
-const util = require('util');
-const msgpack = require('msgpack-lite');
+var redis = require('redis');
+var events = require('events');
+var util = require('util');
+var msgpack = require('msgpack-lite');
 
 var Job = require('./job');
 var defaults = require('./defaults');

--- a/package.json
+++ b/package.json
@@ -4,17 +4,19 @@
   "description": "A simple, fast, robust job/task queue, backed by Redis.",
   "main": "index.js",
   "dependencies": {
-    "redis": "^2.6.3",
-	"msgpack-lite": "^0.1.26"
+    "grunt": "^1.0.1",
+    "msgpack-lite": "^0.1.26",
+    "redis": "^2.6.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "coveralls": "^2.11.2",
     "grunt": "^1.0.1",
-    "grunt-eslint": "^19.0.0",
+    "grunt-cli": "^1.2.0",
+    "grunt-eslint": "^18.1.0",
     "grunt-githooks": "^0.6.0",
     "grunt-mocha-test": "^0.13.2",
-    "sinon": "^1.12.2",
-    "coveralls": "^2.11.2"
+    "sinon": "^1.12.2"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "A simple, fast, robust job/task queue, backed by Redis.",
   "main": "index.js",
   "dependencies": {
-    "redis": "1.0.0"
+    "redis": "^2.6.3",
+	"msgpack-lite": "^0.1.26"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
-    "grunt": "~0.4.5",
-    "grunt-eslint": "17.1.0",
-    "grunt-githooks": "^0.3.1",
-    "grunt-mocha-test": "^0.12.6",
+    "chai": "^3.5.0",
+    "grunt": "^1.0.1",
+    "grunt-eslint": "^19.0.0",
+    "grunt-githooks": "^0.6.0",
+    "grunt-mocha-test": "^0.13.2",
     "sinon": "^1.12.2",
     "coveralls": "^2.11.2"
   },

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -70,14 +70,12 @@ describe('Queue', function () {
       queue.on('error', function () {
         // Prevent errors from bubbling up into exceptions
       });
-
       queue.process(function (job, jobDone) {
         assert.strictEqual(job.data.foo, 'bar');
-        jobDone();
         done();
+        jobDone();
       });
-
-      queue.bclient.stream.end();
+      queue.bclient.stream.destroy();
       queue.bclient.emit('error', new Error('ECONNRESET'));
 
       queue.createJob({foo: 'bar'}).save();
@@ -107,10 +105,10 @@ describe('Queue', function () {
     it('creates a queue with default redis settings', function (done) {
       queue = Queue('test');
       queue.once('ready', function () {
-        assert.strictEqual(queue.client.connectionOption.host, '127.0.0.1');
-        assert.strictEqual(queue.bclient.connectionOption.host, '127.0.0.1');
-        assert.strictEqual(queue.client.connectionOption.port, 6379);
-        assert.strictEqual(queue.bclient.connectionOption.port, 6379);
+        assert.strictEqual(queue.client.connection_options.host, '127.0.0.1');
+        assert.strictEqual(queue.bclient.connection_options.host, '127.0.0.1');
+        assert.strictEqual(queue.client.connection_options.port, 6379);
+        assert.strictEqual(queue.bclient.connection_options.port, 6379);
         assert.strictEqual(queue.client.selected_db, 0);
         assert.strictEqual(queue.bclient.selected_db, 0);
         done();
@@ -126,8 +124,8 @@ describe('Queue', function () {
       });
 
       queue.once('ready', function () {
-        assert.strictEqual(queue.client.connectionOption.host, 'localhost');
-        assert.strictEqual(queue.bclient.connectionOption.host, 'localhost');
+        assert.strictEqual(queue.client.connection_options.host, 'localhost');
+        assert.strictEqual(queue.bclient.connection_options.host, 'localhost');
         assert.strictEqual(queue.client.selected_db, 1);
         assert.strictEqual(queue.bclient.selected_db, 1);
         done();
@@ -140,7 +138,7 @@ describe('Queue', function () {
       });
 
       queue.once('ready', function () {
-        assert.strictEqual(queue.client.connectionOption.host, '127.0.0.1');
+        assert.strictEqual(queue.client.connection_options.host, '127.0.0.1');
         assert.isUndefined(queue.bclient);
         done();
       });
@@ -156,7 +154,7 @@ describe('Queue', function () {
       assert.ok(job.id);
       queue.client.hget('bq:test:jobs', job.id, function (getErr, jobData) {
         assert.isNull(getErr);
-        assert.strictEqual(jobData, job.toData());
+        assert.strictEqual(jobData.toString(), job.toData().toString());
         done();
       });
     });
@@ -257,7 +255,7 @@ describe('Queue', function () {
         assert.ok(createdJob.id);
         queue.getJob(createdJob.id, function (getErr, job) {
           assert.isNull(getErr);
-          assert.strictEqual(job.toData(), createdJob.toData());
+          assert.strictEqual(job.toData().toString(), createdJob.toData().toString());
           done();
         });
       });
@@ -273,7 +271,7 @@ describe('Queue', function () {
         assert.ok(createdJob.id);
         reader.getJob(createdJob.id, function (getErr, job) {
           assert.isNull(getErr);
-          assert.strictEqual(job.toData(), createdJob.toData());
+          assert.strictEqual(job.toData().toString(), createdJob.toData().toString());
           done();
         });
       });
@@ -875,13 +873,13 @@ describe('Queue', function () {
       var job = queue.createJob({foo: 'bar'});
       job.on('succeeded', function (result) {
         assert.isTrue(queueEvent);
-        assert.strictEqual(result, undefined);
+        assert.strictEqual(result, null);
         worker.close(done);
       });
       queue.once('job succeeded', function (jobId, result) {
         queueEvent = true;
         assert.strictEqual(jobId, job.id);
-        assert.strictEqual(result, undefined);
+        assert.strictEqual(result, null);
       });
       job.save();
 


### PR DESCRIPTION
updated dependencies: switch to last node redis and last dev tool.
switch to msgpack-lite, best performance and memory use (Reduces ~25% the size of job data).
fixed some tests for new redis/msgpack  and eslint